### PR TITLE
[DOC] entity별 도메인 파일 생성 및 파일 구조 정리 #3

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,0 +1,128 @@
+# DNS Service ERD
+
+> DNS 기반 사이트 제공 서비스 데이터베이스 설계서  
+> v0.1.0 | 2026-02-09
+
+---
+
+## 테이블 목록 (4개)
+
+| 도메인 | 테이블 | 설명 |
+|---|---|---|
+| **member** | `member` | 회원(계정) |
+| **managed-domain** | `domain` | 사용자가 등록/관리하는 도메인 |
+| **dns** | `dns_record` | DNS 레코드(A/AAAA/CNAME/MX/TXT) |
+| **audit** | `dns_record_history` | DNS 레코드 변경 이력(감사 로그) |
+
+---
+
+## ERD 관계도
+
+```text
+member
+  └─ 1:N ─ domain
+            └─ 1:N ─ dns_record
+                      └─ 1:N ─ dns_record_history
+
+dns_record_history
+  ├─ N:1 ─ dns_record (record_id)
+  ├─ N:1 ─ domain     (domain_id)
+  └─ N:1 ─ member     (changed_by)
+
+```
+
+## ERD 정의 (DDL)
+
+```sql
+-- =========================================================
+-- DNS Service ERD - DDL
+-- =========================================================
+
+CREATE TABLE member
+(
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    login_id   VARCHAR(100)  NOT NULL,
+    email      VARCHAR(255)  NOT NULL,
+    password   VARCHAR(255)  NOT NULL,
+    created_at DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_member_login_id (login_id),
+    UNIQUE KEY uk_member_email (email),
+    INDEX      idx_member_created_at (created_at)
+) ENGINE=InnoDB COMMENT='회원';
+
+CREATE TABLE domain
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    member_id   BIGINT       NOT NULL,
+    domain_name VARCHAR(255) NOT NULL,
+    status      VARCHAR(20)  NOT NULL DEFAULT 'ACTIVE',
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_domain_domain_name (domain_name),
+    INDEX      idx_domain_member_id (member_id),
+    INDEX      idx_domain_status (status),
+    CONSTRAINT fk_domain_member
+        FOREIGN KEY (member_id) REFERENCES member (id),
+    CONSTRAINT chk_domain_status
+        CHECK (status IN ('ACTIVE', 'INACTIVE', 'PENDING', 'SUSPENDED'))
+) ENGINE=InnoDB COMMENT='사용자 관리 도메인';
+
+CREATE TABLE dns_record
+(
+    id            BIGINT       NOT NULL AUTO_INCREMENT,
+    domain_id     BIGINT       NOT NULL,
+    cloudflare_id VARCHAR(100) NULL,
+    type          ENUM('A','AAAA','CNAME','MX','TXT') NOT NULL,
+    host          VARCHAR(255) NOT NULL,
+    value         TEXT         NOT NULL,
+    ttl           INT          NOT NULL DEFAULT 300,
+    priority      INT          NULL,
+    proxied       BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    INDEX         idx_dns_record_domain_id (domain_id),
+    INDEX         idx_dns_record_type (type),
+    INDEX         idx_dns_record_host (host),
+    CONSTRAINT fk_dns_record_domain
+        FOREIGN KEY (domain_id) REFERENCES domain (id),
+    CONSTRAINT chk_dns_record_ttl
+        CHECK (ttl >= 60 AND ttl <= 86400),
+    CONSTRAINT chk_dns_record_priority_mx
+        CHECK (
+            (type = 'MX' AND priority IS NOT NULL)
+            OR
+            (type <> 'MX' AND priority IS NULL)
+        )
+) ENGINE=InnoDB COMMENT='DNS 레코드';
+
+CREATE TABLE dns_record_history
+(
+    id         BIGINT NOT NULL AUTO_INCREMENT,
+    record_id  BIGINT NOT NULL,
+    domain_id  BIGINT NOT NULL,
+    action     ENUM('CREATE','UPDATE','DELETE') NOT NULL,
+    old_value  JSON   NULL,
+    new_value  JSON   NULL,
+    changed_by BIGINT NOT NULL,
+    changed_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    INDEX      idx_dns_record_history_record_id (record_id),
+    INDEX      idx_dns_record_history_domain_id (domain_id),
+    INDEX      idx_dns_record_history_changed_by (changed_by),
+    INDEX      idx_dns_record_history_changed_at (changed_at),
+    CONSTRAINT fk_dns_record_history_record
+        FOREIGN KEY (record_id) REFERENCES dns_record (id),
+    CONSTRAINT fk_dns_record_history_domain
+        FOREIGN KEY (domain_id) REFERENCES domain (id),
+    CONSTRAINT fk_dns_record_history_member
+        FOREIGN KEY (changed_by) REFERENCES member (id)
+) ENGINE=InnoDB COMMENT='DNS 레코드 변경 이력(감사 로그)';
+```
+
+# Enum 정의
+```
+dns_record.type: A, AAAA, CNAME, MX, TXT
+dns_record_history.action: CREATE, UPDATE, DELETE
+```

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,0 +1,59 @@
+﻿# Project Structure
+
+```text
+src/main/java/com/example/gdg
+├─ global
+│  ├─ config
+│  ├─ error
+│  ├─ security
+│  ├─ common
+│  └─ response
+│
+└─ domain
+   ├─ auth                  //인증 인가 관련 도메인
+   │  ├─ controller
+   │  ├─ service
+   │  ├─ dto
+   │  └─ token
+   │
+   ├─ account               //회원 관련 도메인
+   │  ├─ entity
+   │  ├─ repository
+   │  ├─ service
+   │  ├─ controller
+   │  └─ dto
+   │
+   ├─ manageddomain         //도메인 관련 도메인
+   │  ├─ entity
+   │  ├─ repository
+   │  ├─ service
+   │  ├─ controller
+   │  └─ dto
+   │
+   ├─ dns                   //DNS CORS 관련 도메인
+   │  ├─ entity
+   │  ├─ repository
+   │  ├─ service
+   │  ├─ controller
+   │  └─ dto
+   │
+   ├─ provider              //Cloudflare API 호출부
+   │  ├─ cloudflare
+   │  │  ├─ client
+   │  │  ├─ dto
+   │  │  └─ mapper
+   │  └─ service
+   │
+   └─ audit                 //기록 관련 도메인
+      ├─ entity
+      ├─ repository
+      ├─ service
+      └─ listener
+```
+//선민님 작업 내용 이동 참고해주세요!!
+## Current DNS-related code mapping
+- `DnsController` -> `domain/dns/controller`
+- `DnsService` -> `domain/dns/service`
+- `DnsRecord`, `DnsType`, `DnsRecordReq`, `DnsRecordRepository` -> `domain/dns`
+- `CloudflareApiService`, `CloudflareDnsReq`, `CloudflareDnsRes` -> `domain/provider/cloudflare`
+- `DnsRecordHistory`, `ActionType`, `DnsRecordHistoryRepository` -> `domain/audit`

--- a/src/main/java/com/example/gdg/domain/audit/entity/ActionType.java
+++ b/src/main/java/com/example/gdg/domain/audit/entity/ActionType.java
@@ -1,4 +1,4 @@
-package com.example.gdg.entity;
+package com.example.gdg.domain.audit.entity;
 
 public enum ActionType {
     CREATE, UPDATE, DELETE

--- a/src/main/java/com/example/gdg/domain/audit/entity/DnsRecordHistory.java
+++ b/src/main/java/com/example/gdg/domain/audit/entity/DnsRecordHistory.java
@@ -1,4 +1,4 @@
-package com.example.gdg.entity;
+package com.example.gdg.domain.audit.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/gdg/domain/audit/repository/DnsRecordHistoryRepository.java
+++ b/src/main/java/com/example/gdg/domain/audit/repository/DnsRecordHistoryRepository.java
@@ -1,7 +1,8 @@
-package com.example.gdg.repository;
+package com.example.gdg.domain.audit.repository;
 
-import com.example.gdg.entity.DnsRecordHistory;
+import com.example.gdg.domain.audit.entity.DnsRecordHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DnsRecordHistoryRepository extends JpaRepository<DnsRecordHistory, Long> {
 }
+

--- a/src/main/java/com/example/gdg/domain/dns/controller/DnsController.java
+++ b/src/main/java/com/example/gdg/domain/dns/controller/DnsController.java
@@ -1,7 +1,7 @@
-package com.example.gdg.controller;
+package com.example.gdg.domain.dns.controller;
 
-import com.example.gdg.dto.req.DnsRecordReq;
-import com.example.gdg.service.DnsService;
+import com.example.gdg.domain.dns.dto.req.DnsRecordReq;
+import com.example.gdg.domain.dns.service.DnsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -41,3 +41,5 @@ public class DnsController {
         return ResponseEntity.ok().build();
     }
 }
+
+

--- a/src/main/java/com/example/gdg/domain/dns/dto/req/DnsRecordReq.java
+++ b/src/main/java/com/example/gdg/domain/dns/dto/req/DnsRecordReq.java
@@ -1,6 +1,6 @@
-package com.example.gdg.dto.req;
+package com.example.gdg.domain.dns.dto.req;
 
-import com.example.gdg.entity.DnsType;
+import com.example.gdg.domain.dns.entity.DnsType;
 import lombok.Data;
 
 @Data
@@ -13,3 +13,5 @@ public class DnsRecordReq {
     private Integer priority;
     private Boolean proxied;
 }
+
+

--- a/src/main/java/com/example/gdg/domain/dns/entity/DnsRecord.java
+++ b/src/main/java/com/example/gdg/domain/dns/entity/DnsRecord.java
@@ -1,4 +1,4 @@
-package com.example.gdg.entity;
+package com.example.gdg.domain.dns.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/gdg/domain/dns/entity/DnsType.java
+++ b/src/main/java/com/example/gdg/domain/dns/entity/DnsType.java
@@ -1,4 +1,4 @@
-package com.example.gdg.entity;
+package com.example.gdg.domain.dns.entity;
 
 public enum DnsType {
     A, AAAA, CNAME, MX, TXT

--- a/src/main/java/com/example/gdg/domain/dns/repository/DnsRecordRepository.java
+++ b/src/main/java/com/example/gdg/domain/dns/repository/DnsRecordRepository.java
@@ -1,7 +1,8 @@
-package com.example.gdg.repository;
+package com.example.gdg.domain.dns.repository;
 
-import com.example.gdg.entity.DnsRecord;
+import com.example.gdg.domain.dns.entity.DnsRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DnsRecordRepository extends JpaRepository<DnsRecord, Long> {
 }
+

--- a/src/main/java/com/example/gdg/domain/dns/service/DnsService.java
+++ b/src/main/java/com/example/gdg/domain/dns/service/DnsService.java
@@ -1,9 +1,12 @@
-package com.example.gdg.service;
+package com.example.gdg.domain.dns.service;
 
-import com.example.gdg.dto.req.DnsRecordReq;
-import com.example.gdg.entity.*;
-import com.example.gdg.repository.*;
-import com.example.gdg.entity.ActionType;
+import com.example.gdg.domain.audit.entity.ActionType;
+import com.example.gdg.domain.audit.entity.DnsRecordHistory;
+import com.example.gdg.domain.audit.repository.DnsRecordHistoryRepository;
+import com.example.gdg.domain.dns.dto.req.DnsRecordReq;
+import com.example.gdg.domain.dns.entity.DnsRecord;
+import com.example.gdg.domain.dns.repository.DnsRecordRepository;
+import com.example.gdg.domain.provider.cloudflare.client.CloudflareApiService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/gdg/domain/provider/cloudflare/client/CloudflareApiService.java
+++ b/src/main/java/com/example/gdg/domain/provider/cloudflare/client/CloudflareApiService.java
@@ -1,8 +1,8 @@
-package com.example.gdg.service;
+package com.example.gdg.domain.provider.cloudflare.client;
 
-import com.example.gdg.dto.req.CloudflareDnsReq;
-import com.example.gdg.dto.res.CloudflareDnsRes;
-import com.example.gdg.entity.DnsRecord;
+import com.example.gdg.domain.provider.cloudflare.dto.req.CloudflareDnsReq;
+import com.example.gdg.domain.provider.cloudflare.dto.res.CloudflareDnsRes;
+import com.example.gdg.domain.dns.entity.DnsRecord;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -74,3 +74,6 @@ public class CloudflareApiService {
                 .toBodilessEntity();
     }
 }
+
+
+

--- a/src/main/java/com/example/gdg/domain/provider/cloudflare/dto/req/CloudflareDnsReq.java
+++ b/src/main/java/com/example/gdg/domain/provider/cloudflare/dto/req/CloudflareDnsReq.java
@@ -1,4 +1,4 @@
-package com.example.gdg.dto.req;
+package com.example.gdg.domain.provider.cloudflare.dto.req;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/gdg/domain/provider/cloudflare/dto/res/CloudflareDnsRes.java
+++ b/src/main/java/com/example/gdg/domain/provider/cloudflare/dto/res/CloudflareDnsRes.java
@@ -1,4 +1,4 @@
-package com.example.gdg.dto.res;
+package com.example.gdg.domain.provider.cloudflare.dto.res;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/gdg/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/gdg/global/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.example.gdg.config;
+package com.example.gdg.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;


### PR DESCRIPTION
﻿## 작업 내용
- 파일구조 변경
- erd 문서 추가

## 변경 사항
- 변경된 파일구조

├─ global
│  ├─ config
│  ├─ error
│  ├─ security
│  ├─ common (BaseTimeEntity, enums, utils)
│  └─ response (ApiEnvelope 등)
│
└─ domain
   ├─ auth
   │  ├─ controller
   │  ├─ service
   │  ├─ dto
   │  └─ token (jwt/refresh 등 세부)
   │
   ├─ account        // member를 account로 부르는 팀도 많음(선택)
   │  ├─ entity      // Member
   │  ├─ repository
   │  ├─ service
   │  ├─ controller
   │  └─ dto
   │
   ├─ manageddomain  // ★ domain 테이블 담당 (이름 충돌 피하기)
   │  ├─ entity      // ManagedDomain (기존 domain)
   │  ├─ repository
   │  ├─ service
   │  ├─ controller
   │  └─ dto
   │
   ├─ dns
   │  ├─ entity      // DnsRecord
   │  ├─ repository
   │  ├─ service
   │  ├─ controller
   │  ├─ dto
   │  └─ validator   // host/value/type 검증 로직 모음
   │
   ├─ provider
   │  ├─ cloudflare
   │  │  ├─ client        // Cloudflare API 호출부(Feign/RestClient)
   │  │  ├─ dto
   │  │  └─ mapper
   │  └─ service          // “provider 추상화” 레이어
   │
   └─ audit
      ├─ entity      // DnsRecordHistory (혹은 AuditLog)
      ├─ repository
      ├─ service
      └─ listener    // 레코드 변경 이벤트를 받아 history 적재


## 테스트
- [ ] 로컬 테스트 완료
- [ ] Swagger 확인

## 관련 이슈
- closes #3 

## PR 제목 규칙
- [FEAT] / [FIX] / [DOC] / [REFACTOR] / [CHORE]
