### PR TITLE
[FEAT] local 데이터베이스 설정 (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ src/main/resources/application.yml
 src/main/resources/application.properties
 **/application.yml
 **/application.properties
+src/main/resources/application-local.yml
+.env
+.env.*
+!.env.example

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: mysql:8.0
+    container_name: team-local-db
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: my_project_db
+      MYSQL_USER: GDG
+      MYSQL_PASSWORD: gdg123
+      MYSQL_ROOT_PASSWORD: root123
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+volumes:
+  mysql-data:

--- a/src/main/java/com/example/gdg/GdgApplication.java
+++ b/src/main/java/com/example/gdg/GdgApplication.java
@@ -1,6 +1,8 @@
 package com.example.gdg;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -14,9 +16,10 @@ public class GdgApplication {
         SpringApplication.run(GdgApplication.class, args);
     }
 
-
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/src/main/resources/application-local.example.yml
+++ b/src/main/resources/application-local.example.yml
@@ -1,0 +1,22 @@
+﻿spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/my_project_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${SPRING_DATASOURCE_USERNAME:GDG}
+    password: ${SPRING_DATASOURCE_PASSWORD:gdg123}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+
+cloudflare:
+  api-token: ${CLOUDFLARE_API_TOKEN:dummy}
+  zone-id: ${CLOUDFLARE_ZONE_ID:dummy}
+  base-url: ${CLOUDFLARE_BASE_URL:https://api.cloudflare.com/client/v4}
+


### PR DESCRIPTION
 ## 작업 내용

  - 로컬 개발 환경에서 DB 설정 누락으로 서버가 기동 실패하던 문제를 해결
  - 인증/예외 응답 직렬화 시 LocalDateTime 처리 오류를 해결
  - 로컬 실행 시 필수 설정 누락으로 인한 부팅 실패를 줄이기 위한 기본 개발 설정 정리

  ## 변경 사항

  - docker-compose.yml 추가
      - MySQL 8.0 로컬 컨테이너 구성 (my_project_db, GDG/gdg123)
  - 로컬 프로필 설정 파일 추가
      - src/main/resources/application-local.example.yml 추가
      - application-local.yml 로컬용 구성 반영(.gitignore 처리)
  - 기본 설정 보완
      - src/main/resources/application.yml
          - spring.profiles.default=local 추가
          - cloudflare 관련 placeholder 기본값 추가 (api-token, zone-id, base-url)
  - Jackson 직렬화 이슈 수정
      - build.gradle에 jackson-datatype-jsr310 추가
      - GdgApplication에 ObjectMapper 빈 등록 (JavaTimeModule, timestamp 비활성화)
  - 보안/환경 파일 ignore 강화
      - .gitignore에 application-local.yml, .env* 추가


## 테스트
- [x] 로컬 테스트 완료
- [ ] Swagger 확인

## 관련 이슈
- closes #10 

## PR 제목 규칙
- [FEAT] / [FIX] / [DOC] / [REFACTOR] / [CHORE]
