### PR TITLE
[BUG] 회원가입 비밀번호 오류 수정 #12

### DIFF
--- a/src/main/java/com/example/gdg/domain/auth/dto/req/ChangePasswordReq.java
+++ b/src/main/java/com/example/gdg/domain/auth/dto/req/ChangePasswordReq.java
@@ -8,9 +8,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ChangePasswordReq {
 
-    @NotBlank(message = "currentPassword is required.")
+    @NotBlank(message = "현재 비밀번호는 필수입니다.")
     private String currentPassword;
 
-    @NotBlank(message = "newPassword is required.")
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
     private String newPassword;
 }

--- a/src/main/java/com/example/gdg/domain/auth/dto/req/LoginReq.java
+++ b/src/main/java/com/example/gdg/domain/auth/dto/req/LoginReq.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LoginReq {
 
-    @NotBlank(message = "email is required.")
-    @Email(message = "Invalid email format.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
-    @NotBlank(message = "password is required.")
+    @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
 }

--- a/src/main/java/com/example/gdg/domain/auth/dto/req/ReissueReq.java
+++ b/src/main/java/com/example/gdg/domain/auth/dto/req/ReissueReq.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReissueReq {
 
-    @NotBlank(message = "refreshToken is required.")
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
     private String refreshToken;
 }

--- a/src/main/java/com/example/gdg/domain/auth/dto/req/SignUpReq.java
+++ b/src/main/java/com/example/gdg/domain/auth/dto/req/SignUpReq.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SignUpReq {
 
-    @NotBlank(message = "email is required.")
-    @Email(message = "Invalid email format.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
-    @NotBlank(message = "password is required.")
+    @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
 }

--- a/src/main/java/com/example/gdg/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/gdg/domain/auth/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
         validateSignUpRequest(request);
 
         if (authMemberRepository.existsByEmail(request.getEmail())) {
-            throw new IllegalArgumentException("email already exists.");
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
         }
 
         Member member = Member.builder()
@@ -46,10 +46,10 @@ public class AuthService {
         validateLoginRequest(request);
 
         Member member = authMemberRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials."));
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
-            throw new IllegalArgumentException("Invalid credentials.");
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 
         return authTokenService.createTokenPair(member.getId(), member.getEmail());
@@ -57,7 +57,7 @@ public class AuthService {
 
     public AuthTokenRes reissue(ReissueReq request) {
         if (request.getRefreshToken() == null || request.getRefreshToken().isBlank()) {
-            throw new IllegalArgumentException("refreshToken is required.");
+            throw new IllegalArgumentException("리프레시 토큰은 필수입니다.");
         }
         return authTokenService.reissue(request.getRefreshToken());
     }
@@ -66,10 +66,10 @@ public class AuthService {
         validateChangePasswordRequest(request);
 
         Member member = authMemberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Member not found."));
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
 
         if (!passwordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
-            throw new IllegalArgumentException("Current password does not match.");
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
         }
 
         member.changePassword(passwordEncoder.encode(request.getNewPassword()));
@@ -77,31 +77,31 @@ public class AuthService {
 
     private void validateSignUpRequest(SignUpReq request) {
         if (request.getEmail() == null || request.getEmail().isBlank()) {
-            throw new IllegalArgumentException("email is required.");
+            throw new IllegalArgumentException("이메일은 필수입니다.");
         }
         if (!EMAIL_PATTERN.matcher(request.getEmail()).matches()) {
-            throw new IllegalArgumentException("Invalid email format.");
+            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
         }
         if (request.getPassword() == null || request.getPassword().isBlank()) {
-            throw new IllegalArgumentException("password is required.");
+            throw new IllegalArgumentException("비밀번호는 필수입니다.");
         }
     }
 
     private void validateLoginRequest(LoginReq request) {
         if (request.getPassword() == null || request.getPassword().isBlank()) {
-            throw new IllegalArgumentException("password is required.");
+            throw new IllegalArgumentException("비밀번호는 필수입니다.");
         }
         if (request.getEmail() == null || request.getEmail().isBlank()) {
-            throw new IllegalArgumentException("email is required.");
+            throw new IllegalArgumentException("이메일은 필수입니다.");
         }
     }
 
     private void validateChangePasswordRequest(ChangePasswordReq request) {
         if (request.getCurrentPassword() == null || request.getCurrentPassword().isBlank()) {
-            throw new IllegalArgumentException("currentPassword is required.");
+            throw new IllegalArgumentException("현재 비밀번호는 필수입니다.");
         }
         if (request.getNewPassword() == null || request.getNewPassword().isBlank()) {
-            throw new IllegalArgumentException("newPassword is required.");
+            throw new IllegalArgumentException("새 비밀번호는 필수입니다.");
         }
     }
 }

--- a/src/main/java/com/example/gdg/domain/auth/token/AuthTokenService.java
+++ b/src/main/java/com/example/gdg/domain/auth/token/AuthTokenService.java
@@ -44,16 +44,16 @@ public class AuthTokenService {
         String tokenId = claims.get("tokenId", String.class);
 
         RefreshToken savedToken = refreshTokenRepository.findByTokenIdAndMemberId(tokenId, memberId)
-                .orElseThrow(() -> new UnauthorizedException("Invalid refresh token."));
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 리프레시 토큰입니다."));
 
         if (Boolean.TRUE.equals(savedToken.getRevoked())) {
-            throw new UnauthorizedException("Refresh token is revoked.");
+            throw new UnauthorizedException("이미 폐기된 리프레시 토큰입니다.");
         }
         if (savedToken.isExpired(LocalDateTime.now())) {
-            throw new UnauthorizedException("Refresh token is expired.");
+            throw new UnauthorizedException("만료된 리프레시 토큰입니다.");
         }
         if (!matchesToken(refreshToken, savedToken.getTokenHash())) {
-            throw new UnauthorizedException("Invalid refresh token.");
+            throw new UnauthorizedException("유효하지 않은 리프레시 토큰입니다.");
         }
 
         String accessToken = jwtTokenProvider.generateAccessToken(memberId, email);
@@ -79,16 +79,16 @@ public class AuthTokenService {
             Claims claims = jwtTokenProvider.parseClaims(refreshToken);
             String tokenType = claims.get("tokenType", String.class);
             if (!"REFRESH".equals(tokenType)) {
-                throw new UnauthorizedException("Invalid refresh token type.");
+                throw new UnauthorizedException("리프레시 토큰 타입이 올바르지 않습니다.");
             }
             if (claims.get("tokenId", String.class) == null || claims.get("tokenId", String.class).isBlank()) {
-                throw new UnauthorizedException("Invalid refresh token.");
+                throw new UnauthorizedException("유효하지 않은 리프레시 토큰입니다.");
             }
             return claims;
         } catch (UnauthorizedException e) {
             throw e;
         } catch (Exception e) {
-            throw new UnauthorizedException("Invalid refresh token.");
+            throw new UnauthorizedException("유효하지 않은 리프레시 토큰입니다.");
         }
     }
 
@@ -132,7 +132,7 @@ public class AuthTokenService {
             byte[] hashed = digest.digest(token.getBytes(StandardCharsets.UTF_8));
             return Base64.getEncoder().encodeToString(hashed);
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Failed to initialize token hash algorithm.", e);
+            throw new IllegalStateException("토큰 해시 알고리즘 초기화에 실패했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/example/gdg/domain/auth/token/AuthTokenService.java
+++ b/src/main/java/com/example/gdg/domain/auth/token/AuthTokenService.java
@@ -12,7 +12,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.UUID;
 
 @Service
@@ -48,7 +52,7 @@ public class AuthTokenService {
         if (savedToken.isExpired(LocalDateTime.now())) {
             throw new UnauthorizedException("Refresh token is expired.");
         }
-        if (!passwordEncoder.matches(refreshToken, savedToken.getTokenHash())) {
+        if (!matchesToken(refreshToken, savedToken.getTokenHash())) {
             throw new UnauthorizedException("Invalid refresh token.");
         }
 
@@ -62,7 +66,7 @@ public class AuthTokenService {
         RefreshToken rotatedToken = RefreshToken.builder()
                 .memberId(memberId)
                 .tokenId(newTokenId)
-                .tokenHash(passwordEncoder.encode(newRefreshToken))
+                .tokenHash(hashToken(newRefreshToken))
                 .expiresAt(LocalDateTime.now().plusSeconds(refreshTokenValiditySeconds))
                 .build();
         refreshTokenRepository.save(rotatedToken);
@@ -95,7 +99,7 @@ public class AuthTokenService {
         RefreshToken savedToken = RefreshToken.builder()
                 .memberId(memberId)
                 .tokenId(tokenId)
-                .tokenHash(passwordEncoder.encode(refreshToken))
+                .tokenHash(hashToken(refreshToken))
                 .expiresAt(LocalDateTime.now().plusSeconds(refreshTokenValiditySeconds))
                 .build();
         refreshTokenRepository.save(savedToken);
@@ -109,5 +113,26 @@ public class AuthTokenService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    private boolean matchesToken(String rawToken, String storedHash) {
+        // Backward compatibility for previously issued BCrypt-hashed refresh tokens.
+        if (storedHash != null && storedHash.startsWith("$2")) {
+            return passwordEncoder.matches(rawToken, storedHash);
+        }
+        return MessageDigest.isEqual(
+                hashToken(rawToken).getBytes(StandardCharsets.UTF_8),
+                storedHash.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Failed to initialize token hash algorithm.", e);
+        }
     }
 }

--- a/src/main/java/com/example/gdg/domain/dns/service/DnsService.java
+++ b/src/main/java/com/example/gdg/domain/dns/service/DnsService.java
@@ -50,7 +50,7 @@ public class DnsService {
     // 수정
     public void updateDnsRecord(Long recordId, DnsRecordReq request, Long memberId) {
         DnsRecord dnsRecord = dnsRecordRepository.findById(recordId)
-                .orElseThrow(() -> new IllegalArgumentException("Record not found"));
+                .orElseThrow(() -> new IllegalArgumentException("레코드를 찾을 수 없습니다."));
 
         String oldJson = toJson(dnsRecord);
 
@@ -69,7 +69,7 @@ public class DnsService {
     // 삭제
     public void deleteDnsRecord(Long recordId, Long memberId) {
         DnsRecord dnsRecord = dnsRecordRepository.findById(recordId)
-                .orElseThrow(() -> new IllegalArgumentException("Record not found"));
+                .orElseThrow(() -> new IllegalArgumentException("레코드를 찾을 수 없습니다."));
 
         String oldJson = toJson(dnsRecord);
 

--- a/src/main/java/com/example/gdg/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/gdg/global/error/GlobalExceptionHandler.java
@@ -20,7 +20,7 @@ public class GlobalExceptionHandler {
         String message = e.getBindingResult().getFieldErrors().stream()
                 .findFirst()
                 .map(fieldError -> fieldError.getDefaultMessage())
-                .orElse("Invalid request.");
+                .orElse("잘못된 요청입니다.");
 
         return ResponseEntity.badRequest().body(
                 ErrorResponse.builder()
@@ -75,7 +75,7 @@ public class GlobalExceptionHandler {
                         .timestamp(LocalDateTime.now())
                         .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                         .code("INTERNAL_SERVER_ERROR")
-                        .message("Unexpected server error.")
+                        .message("예기치 못한 서버 오류가 발생했습니다.")
                         .path(request.getRequestURI())
                         .build()
         );

--- a/src/main/java/com/example/gdg/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/gdg/global/security/handler/CustomAccessDeniedHandler.java
@@ -35,7 +35,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
                 .timestamp(LocalDateTime.now())
                 .status(HttpStatus.UNAUTHORIZED.value())
                 .code("AUTH_REQUIRED")
-                .message("Authentication is required.")
+                .message("인증이 필요합니다.")
                 .path(request.getRequestURI())
                 .build();
 

--- a/src/main/java/com/example/gdg/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/gdg/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -39,7 +39,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                 .timestamp(LocalDateTime.now())
                 .status(HttpStatus.UNAUTHORIZED.value())
                 .code("AUTH_REQUIRED")
-                .message("Authentication is required.")
+                .message("인증이 필요합니다.")
                 .path(request.getRequestURI())
                 .build();
 

--- a/src/main/java/com/example/gdg/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/gdg/global/security/jwt/JwtTokenProvider.java
@@ -88,7 +88,7 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(token);
         String tokenType = claims.get("tokenType", String.class);
         if (!"ACCESS".equals(tokenType)) {
-            throw new IllegalArgumentException("Invalid token type.");
+            throw new IllegalArgumentException("토큰 타입이 올바르지 않습니다.");
         }
 
         String memberId = claims.getSubject();


### PR DESCRIPTION
 ## 작업 내용

  - 회원가입/토큰 재발급 시 발생하던 password cannot be more than 72 bytes 오류를 해결했습니다.
  - 원인은 refresh token(JWT)을 BCrypt로 해시하던 구조였고, BCrypt의 72바이트 제한에 걸리던 문제였습니다.
  - refresh token 저장/검증 로직을 토큰 전용 해시 방식으로 분리해 인증 흐름이 정상 동작하도록 수정했습니다.
  - 부수적으로 일부 에러 메시지를 한국어로 정리했습니다.

  ## 변경 사항

  - AuthTokenService 중심 수정 (메인 변경)
  - refreshToken 해시 저장 방식 변경
      - 기존: passwordEncoder.encode(refreshToken) (BCrypt)
      - 변경: SHA-256(Base64) 해시 저장
  - refreshToken 검증 방식 변경
      - 기존: passwordEncoder.matches(...)
      - 변경: 해시 비교(SHA-256(Base64))
  - 기존 데이터 호환 처리 추가
      - DB에 기존 bcrypt 해시($2...)가 남아있는 경우 fallback 검증 지원
  - 관련 예외 메시지 일부 한국어화 (부수 변경)
  - Validation/전역 예외 메시지 일부 한국어화

## 테스트
- [ ] 로컬 테스트 완료
- [ ] Swagger 확인

## 관련 이슈
- closes #12 

## PR 제목 규칙
- [FEAT] / [FIX] / [DOC] / [REFACTOR] / [CHORE]
